### PR TITLE
Adding properties callback on dbus

### DIFF
--- a/libs/dbus_util/inc/public/tfc/dbus/match_rules.hpp
+++ b/libs/dbus_util/inc/public/tfc/dbus/match_rules.hpp
@@ -92,9 +92,13 @@ static constexpr std::string_view destination{ detail::filter<detail::destinatio
 /// \tparam interface_name interface name
 /// \tparam object_path object path
 /// \tparam type type
-/// \example tfc::dbus::match::rules::make_match_rule<ipc_ruler_service_name_c_, ipc_ruler_interface_name_c_, ipc_ruler_object_path_c_, tfc::dbus::match::rules::type::signal>()),
-/// Reference: https://dbus.freedesktop.org/doc/dbus-specification.html
-template <std::string_view const& service_name, std::string_view const& interface_name, std::string_view const& object_path, std::string_view const& type>
+/// \example tfc::dbus::match::rules::make_match_rule<ipc_ruler_service_name_c_, ipc_ruler_interface_name_c_,
+/// ipc_ruler_object_path_c_, tfc::dbus::match::rules::type::signal>()), Reference:
+/// https://dbus.freedesktop.org/doc/dbus-specification.html
+template <std::string_view const& service_name,
+          std::string_view const& interface_name,
+          std::string_view const& object_path,
+          std::string_view const& type>
 static constexpr std::string_view make_match_rule() {
   return stx::string_view_join_v<sender<service_name>, interface<interface_name>, path<object_path>, type>;
 }

--- a/libs/dbus_util/inc/public/tfc/dbus/match_rules.hpp
+++ b/libs/dbus_util/inc/public/tfc/dbus/match_rules.hpp
@@ -2,7 +2,6 @@
 
 #include <string_view>
 #include <tfc/stx/string_view_join.hpp>
-#include <sdbusplus/bus/match.hpp>
 
 namespace tfc::dbus::match::rules {
 namespace type {

--- a/libs/dbus_util/inc/public/tfc/dbus/match_rules.hpp
+++ b/libs/dbus_util/inc/public/tfc/dbus/match_rules.hpp
@@ -2,6 +2,7 @@
 
 #include <string_view>
 #include <tfc/stx/string_view_join.hpp>
+#include <sdbusplus/bus/match.hpp>
 
 namespace tfc::dbus::match::rules {
 namespace type {
@@ -86,5 +87,17 @@ static constexpr std::string_view path_namespace{ detail::filter<detail::path_na
 /// Reference: https://dbus.freedesktop.org/doc/dbus-specification.html
 template <std::string_view const& destination_in>
 static constexpr std::string_view destination{ detail::filter<detail::destination_prefix, destination_in> };
+
+/// \brief make complete dbus match rule
+/// \tparam service_name service name
+/// \tparam interface_name interface name
+/// \tparam object_path object path
+/// \tparam type type
+/// \example tfc::dbus::match::rules::make_match_rule<ipc_ruler_service_name_c_, ipc_ruler_interface_name_c_, ipc_ruler_object_path_c_, tfc::dbus::match::rules::type::signal>()),
+/// Reference: https://dbus.freedesktop.org/doc/dbus-specification.html
+template <std::string_view const& service_name, std::string_view const& interface_name, std::string_view const& object_path, std::string_view const& type>
+static constexpr std::string_view make_match_rule() {
+  return stx::string_view_join_v<sender<service_name>, interface<interface_name>, path<object_path>, type>;
+}
 
 }  // namespace tfc::dbus::match::rules

--- a/libs/ipc/inc/public/tfc/ipc.hpp
+++ b/libs/ipc/inc/public/tfc/ipc.hpp
@@ -74,8 +74,6 @@ public:
 
   [[nodiscard]] auto value() const noexcept { return slot_->get(); }  // todo: value() or get()
 
-  auto something() -> std::string { return "something"; }
-
 private:
   static constexpr std::string_view self_name{ slot_tag };
   std::shared_ptr<details::slot_callback<type_desc>> slot_;

--- a/libs/ipc/inc/public/tfc/ipc.hpp
+++ b/libs/ipc/inc/public/tfc/ipc.hpp
@@ -74,9 +74,7 @@ public:
 
   [[nodiscard]] auto value() const noexcept { return slot_->get(); }  // todo: value() or get()
 
-  auto something() -> std::string {
-    return "something";
-  }
+  auto something() -> std::string { return "something"; }
 
 private:
   static constexpr std::string_view self_name{ slot_tag };

--- a/libs/ipc/inc/public/tfc/ipc.hpp
+++ b/libs/ipc/inc/public/tfc/ipc.hpp
@@ -3,6 +3,7 @@
 #include <system_error>
 
 #include <tfc/ipc/details/dbus_server_iface.hpp>
+#include <tfc/ipc/details/dbus_server_iface_mock.hpp>
 #include <tfc/ipc/details/impl.hpp>
 
 namespace tfc::ipc {
@@ -72,6 +73,10 @@ public:
   auto operator=(slot const&) -> slot& = delete;
 
   [[nodiscard]] auto value() const noexcept { return slot_->get(); }  // todo: value() or get()
+
+  auto something() -> std::string {
+    return "something";
+  }
 
 private:
   static constexpr std::string_view self_name{ slot_tag };

--- a/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
+++ b/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
@@ -269,9 +269,9 @@ public:
         std::string(signals_property), sdbusplus::vtable::property_::emits_change,
         [&](const auto&) { return glz::write_json(ipc_manager_->get_all_signals()); });
 
-    dbus_interface_->register_property_r<std::string>(std::string(slots_property), sdbusplus::vtable::property_::emits_change, [&](const auto&) {
-      return glz::write_json(ipc_manager_->get_all_slots());
-    });
+    dbus_interface_->register_property_r<std::string>(
+        std::string(slots_property), sdbusplus::vtable::property_::emits_change,
+        [&](const auto&) { return glz::write_json(ipc_manager_->get_all_slots()); });
 
     dbus_interface_->register_property_r<std::string>(
         "Connections", sdbusplus::vtable::property_::emits_change,

--- a/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
+++ b/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
@@ -456,7 +456,8 @@ public:
    * Register a callback function that gets "pinged" each time there is a change in the properties of the ipc manager
    * @param match_change_callback a function like object on each property change that gets called with the dbus message
    * @return a unique pointer to the match object, this is needed to keep the match object alive
-   * @note The match object is kept alive by the unique pointer, if the unique pointer is destroyed the match object will be destroyed.
+   * @note The match object is kept alive by the unique pointer, if the unique pointer is destroyed the match object will be
+   * destroyed.
    */
   auto register_properties_change_callback(std::function<void(sdbusplus::message_t&)> match_change_callback)
       -> std::unique_ptr<sdbusplus::bus::match::match> {

--- a/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
+++ b/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
@@ -292,8 +292,8 @@ public:
     connection_ = std::make_unique<sdbusplus::asio::connection>(ctx, tfc::dbus::sd_bus_open_system());
     connection_match_ = make_match(
         std::string(
-            tfc::dbus::match::rules::make_match_rule<ipc_ruler_service_name_c_, ipc_ruler_interface_name_c_,
-                                                     ipc_ruler_object_path_c_, tfc::dbus::match::rules::type::signal>()),
+            tfc::dbus::match::rules::make_match_rule<const_ipc_ruler_service_name, const_ipc_ruler_interface_name,
+                                                     const_ipc_ruler_object_path, tfc::dbus::match::rules::type::signal>()),
         std::bind_front(&ipc_manager_client::match_callback, this));
   }
   // Todo copy constructors can be implemented but I don't see why we need them
@@ -306,8 +306,8 @@ public:
     // it could throw if we are out of memory, but then we are already screwed and the process will terminate.
     connection_match_ = make_match(
         std::string(
-            tfc::dbus::match::rules::make_match_rule<ipc_ruler_service_name_c_, ipc_ruler_interface_name_c_,
-                                                     ipc_ruler_object_path_c_, tfc::dbus::match::rules::type::signal>()),
+            tfc::dbus::match::rules::make_match_rule<const_ipc_ruler_service_name, const_ipc_ruler_interface_name,
+                                                     const_ipc_ruler_object_path, tfc::dbus::match::rules::type::signal>()),
         std::bind_front(&ipc_manager_client::match_callback, this));
   }
   auto operator=(ipc_manager_client&& to_be_erased) noexcept -> ipc_manager_client& {
@@ -317,8 +317,8 @@ public:
     // it could throw if we are out of memory, but then we are already screwed and the process will terminate.
     connection_match_ = make_match(
         std::string(
-            tfc::dbus::match::rules::make_match_rule<ipc_ruler_service_name_c_, ipc_ruler_interface_name_c_,
-                                                     ipc_ruler_object_path_c_, tfc::dbus::match::rules::type::signal>()),
+            tfc::dbus::match::rules::make_match_rule<const_ipc_ruler_service_name, const_ipc_ruler_interface_name,
+                                                     const_ipc_ruler_object_path, tfc::dbus::match::rules::type::signal>()),
         std::bind_front(&ipc_manager_client::match_callback, this));
     return *this;
   }
@@ -482,9 +482,6 @@ private:
   const std::string ipc_ruler_service_name_{ const_ipc_ruler_service_name };
   const std::string ipc_ruler_interface_name_{ const_ipc_ruler_interface_name };
   const std::string ipc_ruler_object_path_{ const_ipc_ruler_object_path };
-  static constexpr std::string_view ipc_ruler_service_name_c_{ const_ipc_ruler_service_name };
-  static constexpr std::string_view ipc_ruler_interface_name_c_{ const_ipc_ruler_interface_name };
-  static constexpr std::string_view ipc_ruler_object_path_c_{ const_ipc_ruler_object_path };
 
   std::unique_ptr<sdbusplus::asio::connection> connection_;
   std::unique_ptr<sdbusplus::bus::match::match> connection_match_;
@@ -557,8 +554,12 @@ struct ipc_manager_client_mock {
 
   auto signals(std::invocable<const std::vector<signal>&> auto&& handler) -> void { handler(signals_); }
 
+
+    return make_match(sdbusplus::bus::match::rules::propertiesChanged(ipc_ruler_object_path_, ipc_ruler_interface_name_),
+                      match_change_callback);
+
   template <typename callback>
-  auto register_properties_change_callback(callback&& property_callback) -> void {
+  auto register_properties_change_callback(callback&& property_callback) -> std::unique_ptr<sdbusplus::bus::match::match> {
     callback_ = std::forward<callback>(property_callback);
   }
 

--- a/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
+++ b/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
@@ -37,6 +37,8 @@ static constexpr std::string_view disconnect_method{ "Disconnect" };
 static constexpr std::string_view connect_method{ "Connect" };
 static constexpr std::string_view connections_property{ "Connections" };
 
+const char* connection_change = "ConnectionChange";
+
 // service name
 static constexpr auto const_ipc_ruler_service_name = dbus::const_dbus_name<dbus_name>;
 // object path
@@ -294,8 +296,6 @@ private:
   std::unique_ptr<sdbusplus::asio::dbus_interface> dbus_interface_;
   std::unique_ptr<sdbusplus::asio::object_server> object_server_;
   std::unique_ptr<ipc_manager<signal_storage, slot_storage>> ipc_manager_;
-
-  const char* connection_change = "ConnectionChange";
 };
 
 class ipc_manager_client {

--- a/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
+++ b/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
@@ -290,8 +290,8 @@ public:
   explicit ipc_manager_client(boost::asio::io_context& ctx) {
     connection_ = std::make_unique<sdbusplus::asio::connection>(ctx, tfc::dbus::sd_bus_open_system());
     connection_match_ = make_match(fmt::format("sender='{}',interface='{}',path='{}',type='signal'", ipc_ruler_service_name_,
-                                    ipc_ruler_interface_name_, ipc_ruler_object_path_),
-                        std::bind_front(&ipc_manager_client::match_callback, this));
+                                               ipc_ruler_interface_name_, ipc_ruler_object_path_),
+                                   std::bind_front(&ipc_manager_client::match_callback, this));
   }
   // Todo copy constructors can be implemented but I don't see why we need them
   ipc_manager_client(ipc_manager_client const&) = delete;
@@ -302,8 +302,8 @@ public:
     // It is pretty safe to construct new match here it mostly invokes C api where it does not explicitly throw
     // it could throw if we are out of memory, but then we are already screwed and the process will terminate.
     connection_match_ = make_match(fmt::format("sender='{}',interface='{}',path='{}',type='signal'", ipc_ruler_service_name_,
-                                    ipc_ruler_interface_name_, ipc_ruler_object_path_),
-                        std::bind_front(&ipc_manager_client::match_callback, this));
+                                               ipc_ruler_interface_name_, ipc_ruler_object_path_),
+                                   std::bind_front(&ipc_manager_client::match_callback, this));
   }
   auto operator=(ipc_manager_client&& to_be_erased) noexcept -> ipc_manager_client& {
     connection_ = std::move(to_be_erased.connection_);
@@ -311,8 +311,8 @@ public:
     // It is pretty safe to construct new match here it mostly invokes C api where it does not explicitly throw
     // it could throw if we are out of memory, but then we are already screwed and the process will terminate.
     connection_match_ = make_match(fmt::format("sender='{}',interface='{}',path='{}',type='signal'", ipc_ruler_service_name_,
-                                    ipc_ruler_interface_name_, ipc_ruler_object_path_),
-                        std::bind_front(&ipc_manager_client::match_callback, this));
+                                               ipc_ruler_interface_name_, ipc_ruler_object_path_),
+                                   std::bind_front(&ipc_manager_client::match_callback, this));
     return *this;
   }
 

--- a/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
+++ b/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
@@ -454,13 +454,13 @@ public:
   auto register_properties_change_callback(std::function<void(sdbusplus::message_t&)> match_change_callback) -> void {
     properties_match_ =
         make_match(sdbusplus::bus::match::rules::propertiesChanged(ipc_ruler_object_path_, ipc_ruler_interface_name_),
-                   std::move(match_change_callback));
+                   match_change_callback);
   }
 
 private:
   auto make_match(const std::string& match_rule, std::function<void(sdbusplus::message_t&)> callback)
       -> std::unique_ptr<sdbusplus::bus::match::match> {
-    return std::make_unique<sdbusplus::bus::match::match>(*connection_, match_rule, std::move(callback));
+    return std::make_unique<sdbusplus::bus::match::match>(*connection_, match_rule, callback);
   }
   auto match_callback(sdbusplus::message_t& msg) -> void {
     auto container = msg.unpack<std::tuple<std::string, std::string>>();
@@ -547,8 +547,9 @@ struct ipc_manager_client_mock {
 
   auto signals(std::invocable<const std::vector<signal>&> auto&& handler) -> void { handler(signals_); }
 
-  auto register_properties_change_callback(std::function<void(sdbusplus::message_t&)>& callback) -> void {
-    callback_ = callback;
+  template <typename callback>
+  auto register_properties_change_callback(callback&& property_callback) -> void {
+    callback_ = std::forward<callback>(property_callback);
   }
 
   std::vector<slot> slots_;

--- a/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
+++ b/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
@@ -449,7 +449,7 @@ public:
    * Register a callback function that gets "pinged" each time there is a change in the properties of the ipc manager
    * @param match_change_callback a function like object on each property change that gets called with the dbus message
    * @note There can only be a single callback registered for the change in property on the client, if you register a new
-   * one. The old callback will be overwritten.
+   * one the old callback will be overwritten.
    */
   auto register_properties_change_callback(std::function<void(sdbusplus::message_t&)> match_change_callback) -> void {
     properties_match_ =

--- a/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
+++ b/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
@@ -37,7 +37,7 @@ static constexpr std::string_view disconnect_method{ "Disconnect" };
 static constexpr std::string_view connect_method{ "Connect" };
 static constexpr std::string_view connections_property{ "Connections" };
 
-const char* connection_change = "ConnectionChange";
+static const char* connection_change = "ConnectionChange";
 
 // service name
 static constexpr auto const_ipc_ruler_service_name = dbus::const_dbus_name<dbus_name>;

--- a/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface_mock.hpp
+++ b/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface_mock.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+// ipc-manager-client-mock
+// mocks the behavior of ipc-manager-client
+
+#include "dbus_server_iface.hpp"
+
+namespace tfc::ipc_ruler {
+
+struct ipc_manager_client_mock {
+  ipc_manager_client_mock() {}
+
+  auto register_connection_change_callback(std::string_view slot_name,
+                                           const std::function<void(std::string_view const)>& connection_change_callback)
+      -> void {
+    slot_callbacks.emplace(std::string(slot_name), connection_change_callback);
+  }
+
+  std::unordered_map<std::string, std::function<void(std::string_view const)>> slot_callbacks;
+
+  auto register_slot(const std::string_view name,
+                     std::string_view description,
+                     type_e type,
+                     std::invocable<const std::error_code&> auto&& handler) -> void {
+    slots_.emplace_back(slot{ .name = std::string(name),
+                              .type = type,
+                              .created_by = "",
+                              .created_at = std::chrono::system_clock::now(),
+                              .last_registered = std::chrono::system_clock::now(),
+                              .last_modified = std::chrono::system_clock::now(),
+                              .modified_by = "",
+                              .connected_to = "",
+                              .description = std::string(description) });
+    handler(std::error_code());
+  }
+
+  auto register_signal(const std::string_view name,
+                       std::string_view description,
+                       type_e type,
+                       std::invocable<const std::error_code&> auto&& handler) -> void {
+    signals_.emplace_back(signal{ .name = std::string(name),
+                                  .type = type,
+                                  .created_by = "",
+                                  .created_at = std::chrono::system_clock::now(),
+                                  .last_registered = std::chrono::system_clock::now(),
+                                  .description = std::string(description) });
+
+    sdbusplus::message_t dbus_message = sdbusplus::message_t{};
+    for (auto& callback : callbacks_) {
+      callback(dbus_message);
+    }
+
+    handler(std::error_code());
+  }
+
+  auto connect(const std::string& slot_name,
+               const std::string& signal_name,
+               std::invocable<const std::error_code&> auto&& handler) -> void {
+    for (auto& slot : slots_) {
+      if (slot.name == slot_name) {
+        slot.connected_to = signal_name;
+        auto iterator = slot_callbacks.find(slot_name);
+        if (iterator != slot_callbacks.end()) {
+          std::invoke(iterator->second, signal_name);
+        }
+        std::error_code no_err{};
+        handler(no_err);
+        return;
+      }
+    }
+    throw std::runtime_error("Signal not found in mocking list signal_name: " + signal_name + " slot_name: " + slot_name);
+  }
+
+  auto slots(std::invocable<const std::vector<slot>&> auto&& handler) -> void { handler(slots_); }
+
+  auto signals(std::invocable<const std::vector<signal>&> auto&& handler) -> void { handler(signals_); }
+
+  template <typename callback>
+  auto register_properties_change_callback(callback&& property_callback) -> std::unique_ptr<sdbusplus::bus::match::match> {
+    callbacks_.emplace_back(std::forward<callback>(property_callback));
+    return nullptr;
+  }
+
+  std::vector<slot> slots_;
+  std::vector<signal> signals_;
+  std::vector<std::function<void(sdbusplus::message_t&)>> callbacks_ = {};
+};
+
+}  // namespace tfc::ipc_ruler

--- a/libs/ipc/tests/ipc_manager_test.cpp
+++ b/libs/ipc/tests/ipc_manager_test.cpp
@@ -397,7 +397,8 @@ auto main(int argc, char** argv) -> int {
 
     instance.ctx.run_for(std::chrono::milliseconds(20));
 
-    instance.ipc_manager_client.register_properties_change_callback(std::bind_front(&test_instance::increment, &instance));
+    std::unique_ptr<sdbusplus::bus::match::match> cb = instance.ipc_manager_client.register_properties_change_callback(
+        std::bind_front(&test_instance::increment, &instance));
 
     instance.ctx.run_for(std::chrono::milliseconds(20));
 


### PR DESCRIPTION
This change allows an outside class to define a matcher which will invoke a callback whenever a property is changed on the D-bus. 

The callback is then owned by the caller.

The mock client was changed in accordance.