### PR TITLE
Change port to uint16_t

### DIFF
--- a/exes/mqtt-broadcaster/inc/config.hpp
+++ b/exes/mqtt-broadcaster/inc/config.hpp
@@ -1,12 +1,10 @@
-#pragma once
-
 #include <tfc/confman.hpp>
 #include <tfc/confman/observable.hpp>
 
 // File under /etc/tfc/mqtt-broadcaster/def/mqtt_broadcaster.json which specifies the connection values for the MQTT broker.
 struct config {
   std::string address{};
-  std::string port{};
+  uint16_t port{};
   std::string username{};
   std::string password{};
   std::string node_id{};
@@ -17,7 +15,7 @@ struct config {
     // clang-format off
     static constexpr auto value{ glz::object(
         "address", &config::address, "Hostname or IP address of the MQTT broker",
-        "port", &config::port, "Port or service name of the MQTT broker",
+        "port", &config::port, "Port of the MQTT broker",
         "username", &config::username, "Username for the MQTT broker",
         "password", &config::password, "Password for the MQTT broker",
         "node_id", &config::node_id, "Spark Plug B Node ID, used to identify which node is sending information",

--- a/exes/mqtt-broadcaster/inc/mqtt_broadcaster.hpp
+++ b/exes/mqtt-broadcaster/inc/mqtt_broadcaster.hpp
@@ -192,7 +192,7 @@ private:
     tls_ctx_.set_verify_mode(async_mqtt::tls::verify_peer);
 
     asio::ip::tcp::resolver::results_type resolved_ip =
-        co_await res.async_resolve(config_.value().address, config_.value().port, asio::use_awaitable);
+        co_await res.async_resolve(config_.value().address, fmt::format("{}", config_.value().port), asio::use_awaitable);
 
     co_return resolved_ip;
   }


### PR DESCRIPTION
Changing the definition of a port under glaze config to uint16_t instead of string. 