### PR TITLE
Fix default service name of operation mode demon.

### DIFF
--- a/libs/operation_mode/inc/public/tfc/operation_mode.hpp
+++ b/libs/operation_mode/inc/public/tfc/operation_mode.hpp
@@ -28,7 +28,7 @@ concept transition_callback = std::invocable<callback_t, new_mode_e, old_mode_e>
 class interface {
 public:
   explicit interface(boost::asio::io_context& ctx) : interface(ctx, "operation") {}
-  interface(boost::asio::io_context& ctx, std::string_view log_key) : interface(ctx, log_key, dbus::service_default) {}
+  interface(boost::asio::io_context& ctx, std::string_view log_key) : interface(ctx, log_key, dbus::service_name) {}
   /// \brief construct an interface to operation mode controller
   /// \param ctx context to run in
   /// \param log_key key to use for logging

--- a/libs/operation_mode/inc/public/tfc/operation_mode/common.hpp
+++ b/libs/operation_mode/inc/public/tfc/operation_mode/common.hpp
@@ -28,7 +28,7 @@ enum struct mode_e : std::uint8_t {
 
 namespace dbus {
 // Please note that this needs to match the generated service name of the operation mode daemon
-static constexpr std::string_view service_default{ "tfc.Operations.def" };
+static constexpr std::string_view service_default{ "tfc.operations.def" };
 static constexpr std::string_view service_name{ tfc::dbus::const_dbus_name<service_default> };
 static constexpr std::string_view interface_name{ "OperationMode" };
 static constexpr std::string_view name{ tfc::dbus::const_dbus_name<interface_name> };


### PR DESCRIPTION
Maybe we should generate it from cmake instead of string literal?