### PR TITLE
use std::numeric_limits<T>::lowest() instead of ::min()

### DIFF
--- a/libs/stx/inc/public/tfc/utils/json_schema.hpp
+++ b/libs/stx/inc/public/tfc/utils/json_schema.hpp
@@ -267,11 +267,11 @@ struct to_json_schema<T> {
   static void op(auto& s, auto&) noexcept {
     if constexpr (std::integral<T>) {
       s.type = { "integer" };
-      s.attributes.minimum = static_cast<std::int64_t>(std::numeric_limits<T>::min());
+      s.attributes.minimum = static_cast<std::int64_t>(std::numeric_limits<T>::lowest());
       s.attributes.maximum = static_cast<std::uint64_t>(std::numeric_limits<T>::max());
     } else {
       s.type = { "number" };
-      s.attributes.minimum = std::numeric_limits<T>::min();
+      s.attributes.minimum = std::numeric_limits<T>::lowest();
       s.attributes.maximum = std::numeric_limits<T>::max();
     }
   }


### PR DESCRIPTION
Closes #246
::min() references the smallest positive normal amount in the double case a constant from climits called DBL_MIN, ::lowst() describes the lowest amount representable.

See
https://en.cppreference.com/w/cpp/types/numeric_limits/lowest https://en.cppreference.com/w/cpp/types/numeric_limits/min