### PR TITLE
Dont prettify json_schema by default

### DIFF
--- a/libs/stx/inc/public/tfc/utils/json_schema.hpp
+++ b/libs/stx/inc/public/tfc/utils/json_schema.hpp
@@ -484,7 +484,7 @@ inline auto write_json_schema() noexcept {
   detail::schematic s{};
   s.defs.emplace();
   detail::to_json_schema<std::decay_t<T>>::template op<glz::opts{}>(s, *s.defs);
-  glz::write<glz::opts{ .prettify = true, .write_type_info = false }>(std::move(s), buffer);
+  glz::write<glz::opts{ .write_type_info = false }>(std::move(s), buffer);
   return buffer;
 }
 }  // namespace tfc::json


### PR DESCRIPTION
Main consumer for human readable json schema is via d-spy, prettified json does not render properly inside d-spy and all newlines are rendered as characters