### PR TITLE
Allow search to match with slots 

### DIFF
--- a/cockpit/IPC/src/Components/Table/Table.tsx
+++ b/cockpit/IPC/src/Components/Table/Table.tsx
@@ -90,6 +90,7 @@ export default function CustomTable({
    * @param signal The signal that is being checked
   */
   const onFilter = (signal: SignalType) => {
+    console.log(connections);
     const createSafeRegex = (value: string) => {
       try {
         return new RegExp(value, 'i');
@@ -100,9 +101,15 @@ export default function CustomTable({
     let matchesSearchValue;
     if (nameSelection && nameSelection.length !== 0) {
       const searchRegexList = nameSelection.map((value) => createSafeRegex(value));
-      matchesSearchValue = searchRegexList.some(
-        (regex) => (signal.name + signal.created_by).search(regex) >= 0,
-      );
+      matchesSearchValue = searchRegexList.some((regex) => {
+        // Check if the signal name or created_by matches the regex
+        if ((signal.name + signal.created_by).search(regex) >= 0) {
+          return true;
+        }
+        // Check if any connected slot name matches the regex
+        const connectedSlots = connections[signal.name] || [];
+        return connectedSlots.some((slotName) => regex.test(slotName));
+      });
     } else {
       matchesSearchValue = true;
     }

--- a/cockpit/IPC/src/Components/Table/Table.tsx
+++ b/cockpit/IPC/src/Components/Table/Table.tsx
@@ -90,7 +90,6 @@ export default function CustomTable({
    * @param signal The signal that is being checked
   */
   const onFilter = (signal: SignalType) => {
-    console.log(connections);
     const createSafeRegex = (value: string) => {
       try {
         return new RegExp(value, 'i');


### PR DESCRIPTION
This PR lets the name search in the connections UI display matching slots.
![image](https://github.com/Skaginn3x/framework/assets/70705172/8d1a6602-7475-4a0d-b4ea-94e0a03ee9b2)

Previously, name matching was only done on Signals which caused issues when trying to find Slots.
