### PR TITLE
make ipc signal contain optional to represent last value

### DIFF
--- a/exes/ethercat/inc/public/tfc/ec/devices/schneider/atv320.hpp
+++ b/exes/ethercat/inc/public/tfc/ec/devices/schneider/atv320.hpp
@@ -252,11 +252,13 @@ public:
       last_errors_[0] = in->last_error;
       bool auto_reset =
           std::find(errors_to_auto_reset.begin(), errors_to_auto_reset.end(), in->last_error) != errors_to_auto_reset.end();
-      logger_.error("New fault detected {}:{}, will try to auto reset: {}", std::to_underlying(in->last_error) ,in->last_error, auto_reset);
+      logger_.error("New fault detected {}:{}, will try to auto reset: {}", std::to_underlying(in->last_error),
+                    in->last_error, auto_reset);
     } else if (drive_in_fault_state && in->last_error == lft_e::no_fault) {
       logger_.warn("ATV reports fault state but last fault is not set");
     } else if (in->last_error != last_errors_[0]) {
-      logger_.warn("Atv not in fault state but reporting fault: {}:{}, state: {}", std::to_underlying(in->last_error), in->last_error, state);
+      logger_.warn("Atv not in fault state but reporting fault: {}:{}, state: {}", std::to_underlying(in->last_error),
+                   in->last_error, state);
       std::shift_right(last_errors_.begin(), last_errors_.end(), 1);
       last_errors_[0] = in->last_error;
     }

--- a/libs/ipc/inc/public/tfc/ipc.hpp
+++ b/libs/ipc/inc/public/tfc/ipc.hpp
@@ -178,7 +178,7 @@ public:
 
   [[nodiscard]] auto full_name() const noexcept -> std::string { return signal_->full_name(); }
 
-  [[nodiscard]] auto value() const noexcept -> value_t const& { return signal_->value(); }
+  [[nodiscard]] auto value() const noexcept -> std::optional<value_t> const& { return signal_->value(); }
 
 private:
   static auto make_impl_signal(auto&& ctx, auto&& name) {

--- a/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
+++ b/libs/ipc/inc/public/tfc/ipc/details/dbus_server_iface.hpp
@@ -196,7 +196,7 @@ public:
       db_ << fmt::format("SELECT type FROM slots WHERE name = '{}' LIMIT 1;", slot_name) >>
           [&slot_type](const int result) { slot_type = result; };
       if (signal_type != slot_type) {
-        std::string const err_msg = "Signal and slot types dont match";
+        std::string const err_msg = fmt::format("Signal: {} and slot: {}, types dont match", signal_type, slot_type);
         logger_.warn(err_msg);
         throw dbus_error(err_msg);
       }

--- a/libs/ipc/testing/tests/ipc_manager_test.cpp
+++ b/libs/ipc/testing/tests/ipc_manager_test.cpp
@@ -297,15 +297,10 @@ auto main(int argc, char** argv) -> int {
 
     std::array<bool, 3> test_values{ true, false, true };
     uint8_t invocation{};
-    bool ignore_first{ true };
 
     tfc::ipc_ruler::ipc_manager_client_mock mock_client{ isolated_ctx };
     const tfc::ipc::slot<tfc::ipc::details::type_bool, tfc::ipc_ruler::ipc_manager_client_mock&> slot(
         isolated_ctx, mock_client, "bool_slot", "", [&](bool value) {
-          if (ignore_first) {
-            ignore_first = false;
-            return;
-          }
           ut::expect(test_values.at(invocation++) == value);
           if (invocation == test_values.size()) {
             isolated_ctx.stop();
@@ -333,15 +328,10 @@ auto main(int argc, char** argv) -> int {
     tfc::ipc_ruler::ipc_manager_client_mock mock_client{ isolated_ctx };
 
     uint8_t invocation{};
-    bool ignore_first{ true };
     std::array<std::int64_t, 3> test_values{ 25, 1337, 42 };
 
     const tfc::ipc::slot<tfc::ipc::details::type_int, tfc::ipc_ruler::ipc_manager_client_mock&> slot(
         isolated_ctx, mock_client, "bool_slot", "", [&](int64_t value) {
-          if (ignore_first) {
-            ignore_first = false;
-            return;
-          }
           ut::expect(test_values.at(invocation++) == value);
           if (invocation == test_values.size()) {
             isolated_ctx.stop();


### PR DESCRIPTION
this makes it achievable for scada system to write but not override when system is started(the signal is constructed)