### PR TITLE
Added version.hpp to identify versions of running software

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Check if there are missing pragma once
         run: |
           FILES=$(find libs exes -name "*.hpp" -type f -exec grep -H -c '#pragma once' {} \; | grep 0$ | cut -d':' -f1)

--- a/.github/workflows/ubuntu-packaging.yml
+++ b/.github/workflows/ubuntu-packaging.yml
@@ -31,6 +31,8 @@ jobs:
         architecture: [ x86_64, aarch64 ]
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Get release
         if: github.event_name == 'release' && github.event.action == 'created'

--- a/cmake/tfc_version.cmake
+++ b/cmake/tfc_version.cmake
@@ -7,43 +7,36 @@ if(GIT_FOUND)
             COMMAND git log -1 --pretty=format:%H
             OUTPUT_VARIABLE GIT_HASH
             OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET
     )
     execute_process(
             COMMAND git log -1 --pretty=format:"%an <%ae>"
             OUTPUT_VARIABLE GIT_AUTHOR
             OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET
     )
     execute_process(
             COMMAND git branch --show-current
             OUTPUT_VARIABLE GIT_BRANCH
             OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET
     )
     execute_process(
             COMMAND git describe --tags --abbrev=1
             OUTPUT_VARIABLE GIT_TAG
             OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET
     )
     execute_process(
             COMMAND git diff --shortstat
             OUTPUT_VARIABLE GIT_IS_DIRTY_INTERMEDIATE
             OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET
     )
     execute_process(
             COMMAND git log -1 --pretty=format:%as
             OUTPUT_VARIABLE GIT_COMMIT_DATE
             OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET
     )
     execute_process(
             COMMAND date +"%Y-%M-%d %H:%M:%S"
             OUTPUT_VARIABLE BUILD_DATE
             OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET
     )
 else()
     message(FATAL_ERROR "Git not found, cannot generate version.hpp")

--- a/cmake/tfc_version.cmake
+++ b/cmake/tfc_version.cmake
@@ -1,7 +1,7 @@
 # Run this with CMake in "script mode" (-P flag) at build time
 
 # find Git and if available set GIT_HASH variable
-find_package(Git QUIET)
+find_package(Git REQUIRED)
 if(GIT_FOUND)
     execute_process(
             COMMAND git log -1 --pretty=format:%H

--- a/cmake/tfc_version.cmake
+++ b/cmake/tfc_version.cmake
@@ -40,7 +40,7 @@ if(GIT_FOUND)
             ERROR_QUIET
     )
     execute_process(
-            COMMAND date +"%Y-%M-%d"
+            COMMAND date +"%Y-%M-%d %H:%M:%S"
             OUTPUT_VARIABLE BUILD_DATE
             OUTPUT_STRIP_TRAILING_WHITESPACE
             ERROR_QUIET
@@ -62,3 +62,10 @@ message(STATUS "GIT_BRANCH: ${GIT_BRANCH}")
 message(STATUS "GIT_TAG: ${GIT_TAG}")
 message(STATUS "GIT_IS_DIRTY: ${GIT_IS_DIRTY}")
 message(STATUS "GIT_COMMIT_DATE: ${GIT_COMMIT_DATE}")
+
+# generate file version.hpp based on version.hpp.in
+configure_file(
+        ${IN_FILE}
+        ${OUT_FILE}
+        @ONLY
+)

--- a/cmake/tfc_version.cmake
+++ b/cmake/tfc_version.cmake
@@ -4,6 +4,11 @@
 find_package(Git REQUIRED)
 if(GIT_FOUND)
     execute_process(
+            COMMAND git config --global --add safe.directory ${CMAKE_SOURCE_DIR}
+            OUTPUT_VARIABLE GIT_HASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    execute_process(
             COMMAND git log -1 --pretty=format:%H
             OUTPUT_VARIABLE GIT_HASH
             OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/cmake/tfc_version.cmake
+++ b/cmake/tfc_version.cmake
@@ -1,0 +1,64 @@
+# Run this with CMake in "script mode" (-P flag) at build time
+
+# find Git and if available set GIT_HASH variable
+find_package(Git QUIET)
+if(GIT_FOUND)
+    execute_process(
+            COMMAND git log -1 --pretty=format:%H
+            OUTPUT_VARIABLE GIT_HASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+    )
+    execute_process(
+            COMMAND git log -1 --pretty=format:"%an <%ae>"
+            OUTPUT_VARIABLE GIT_AUTHOR
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+    )
+    execute_process(
+            COMMAND git branch --show-current
+            OUTPUT_VARIABLE GIT_BRANCH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+    )
+    execute_process(
+            COMMAND git describe --tags --abbrev=1
+            OUTPUT_VARIABLE GIT_TAG
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+    )
+    execute_process(
+            COMMAND git diff --shortstat
+            OUTPUT_VARIABLE GIT_IS_DIRTY_INTERMEDIATE
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+    )
+    execute_process(
+            COMMAND git log -1 --pretty=format:%as
+            OUTPUT_VARIABLE GIT_COMMIT_DATE
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+    )
+    execute_process(
+            COMMAND date +"%Y-%M-%d"
+            OUTPUT_VARIABLE BUILD_DATE
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+    )
+else()
+    message(FATAL_ERROR "Git not found, cannot generate version.hpp")
+endif()
+# Write git dirty if GIT_DIRTY_INTERMEDIATE is not empty
+if(NOT "${GIT_IS_DIRTY_INTERMEDIATE}" STREQUAL "")
+    set(GIT_IS_DIRTY "dirty")
+else()
+    set(GIT_IS_DIRTY "")
+endif()
+
+# Print all git fields
+message(STATUS "GIT_HASH: ${GIT_HASH}")
+message(STATUS "GIT_AUTHOR: ${GIT_AUTHOR}")
+message(STATUS "GIT_BRANCH: ${GIT_BRANCH}")
+message(STATUS "GIT_TAG: ${GIT_TAG}")
+message(STATUS "GIT_IS_DIRTY: ${GIT_IS_DIRTY}")
+message(STATUS "GIT_COMMIT_DATE: ${GIT_COMMIT_DATE}")

--- a/exes/ethercat/src/base.cpp
+++ b/exes/ethercat/src/base.cpp
@@ -1,5 +1,5 @@
 //
-// This compilation unit is only here to store vtable references.
+// this compilation unit is only here to store vtable references.
 //
 #include "tfc/ec/devices/base.hpp"
 #include "tfc/ec/devices/beckhoff/EK1xxx.hpp"

--- a/libs/progbase/CMakeLists.txt
+++ b/libs/progbase/CMakeLists.txt
@@ -1,8 +1,6 @@
 project(progbase)
 cmake_minimum_required(VERSION 3.21)
 
-include(tfc_version)
-
 add_library(base
   src/progbase.cpp
 )
@@ -36,12 +34,24 @@ if (BUILD_TESTING)
   add_subdirectory(tests)
 endif ()
 
-# generate file version.hpp based on version.hpp.in
-configure_file(
-        ${CMAKE_CURRENT_LIST_DIR}/inc/tfc/version.hpp.in
+add_custom_command(
+        OUTPUT
         ${CMAKE_CURRENT_BINARY_DIR}/inc/tfc/version.hpp
-        @ONLY
+        ALL
+        COMMAND
+        ${CMAKE_COMMAND} -D GIT_HASH=${GIT_HASH} -D GIT_AUTHOR=${GIT_AUTHOR} -D GIT_BRANCH=${GIT_BRANCH} -D GIT_TAG=${GIT_TAG} -D GIT_IS_DIRTY=${GIT_IS_DIRTY} -D GIT_COMMIT_DATE=${GIT_COMMIT_DATE} -D IN_FILE=${CMAKE_CURRENT_SOURCE_DIR}/inc/tfc/version.hpp.in -D OUT_FILE=${CMAKE_CURRENT_BINARY_DIR}/inc/tfc/version.hpp -P ${CMAKE_SOURCE_DIR}/cmake/tfc_version.cmake
+        WORKING_DIRECTORY
+        ${CMAKE_SOURCE_DIR}
 )
 
+add_custom_target(
+        generate_version_header
+        ALL
+        COMMAND
+        ${CMAKE_COMMAND} -D GIT_HASH=${GIT_HASH} -D GIT_AUTHOR=${GIT_AUTHOR} -D GIT_BRANCH=${GIT_BRANCH} -D GIT_TAG=${GIT_TAG} -D GIT_IS_DIRTY=${GIT_IS_DIRTY} -D GIT_COMMIT_DATE=${GIT_COMMIT_DATE} -D IN_FILE=${CMAKE_CURRENT_SOURCE_DIR}/inc/tfc/version.hpp.in -D OUT_FILE=${CMAKE_CURRENT_BINARY_DIR}/inc/tfc/version.hpp -P ${CMAKE_SOURCE_DIR}/cmake/tfc_version.cmake
+        WORKING_DIRECTORY
+        ${CMAKE_SOURCE_DIR}
+)
+add_dependencies(base generate_version_header)
 include(tfc_install)
 tfc_install_lib(base)

--- a/libs/progbase/CMakeLists.txt
+++ b/libs/progbase/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.21)
 
 add_library(base
   src/progbase.cpp
+  src/version.cpp
 )
 add_library(tfc::base ALIAS base)
 get_target_property(TFC_LOGGER_INCLUDE_DIRS tfc::logger INTERFACE_INCLUDE_DIRECTORIES)

--- a/libs/progbase/CMakeLists.txt
+++ b/libs/progbase/CMakeLists.txt
@@ -1,6 +1,8 @@
 project(progbase)
 cmake_minimum_required(VERSION 3.21)
 
+include(tfc_version)
+
 add_library(base
   src/progbase.cpp
 )
@@ -12,11 +14,13 @@ target_include_directories(base
     $<INSTALL_INTERFACE:include>
   PRIVATE
     inc
+    ${CMAKE_CURRENT_BINARY_DIR}/inc
     ${TFC_LOGGER_INCLUDE_DIRS}
 )
 
 find_package(Boost REQUIRED COMPONENTS program_options)
 find_package(fmt CONFIG REQUIRED)
+
 
 target_link_libraries(base
   PRIVATE
@@ -31,6 +35,13 @@ add_library_to_docs(tfc::base)
 if (BUILD_TESTING)
   add_subdirectory(tests)
 endif ()
+
+# generate file version.hpp based on version.hpp.in
+configure_file(
+        ${CMAKE_CURRENT_LIST_DIR}/inc/tfc/version.hpp.in
+        ${CMAKE_CURRENT_BINARY_DIR}/inc/tfc/version.hpp
+        @ONLY
+)
 
 include(tfc_install)
 tfc_install_lib(base)

--- a/libs/progbase/inc/tfc/version.hpp.in
+++ b/libs/progbase/inc/tfc/version.hpp.in
@@ -5,7 +5,8 @@
 namespace tfc::base{
 class version {
 public:
-    ~version();
+    explicit version() = default;
+    virtual ~version();
     virtual constexpr auto get_git_hash() const noexcept -> std::string_view { return git_hash; }
     virtual constexpr auto get_git_tag() const noexcept -> std::string_view { return git_tag; }
     virtual constexpr auto get_git_branch() const noexcept -> std::string_view { return git_branch; }

--- a/libs/progbase/inc/tfc/version.hpp.in
+++ b/libs/progbase/inc/tfc/version.hpp.in
@@ -6,6 +6,10 @@ namespace tfc::base{
 class version {
 public:
     explicit version() = default;
+    version(version const&) = default;
+    version(version&&) = default;
+    auto operator=(version const&) -> version& = default;
+    auto operator=(version&&) -> version& = default;
     virtual ~version();
     virtual constexpr auto get_git_hash() const noexcept -> std::string_view { return git_hash; }
     virtual constexpr auto get_git_tag() const noexcept -> std::string_view { return git_tag; }

--- a/libs/progbase/inc/tfc/version.hpp.in
+++ b/libs/progbase/inc/tfc/version.hpp.in
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string_view>
+
+namespace tfc::base{
+class version {
+public:
+    virtual constexpr auto get_git_hash() const noexcept -> std::string_view { return git_hash; }
+    virtual constexpr auto get_git_tag() const noexcept -> std::string_view { return git_tag; }
+    virtual constexpr auto get_git_branch() const noexcept -> std::string_view { return git_branch; }
+    virtual constexpr auto get_git_author() const noexcept -> std::string_view { return git_author; }
+    virtual constexpr auto get_git_is_dirty() const noexcept -> std::string_view { return git_is_dirty; }
+    virtual constexpr auto get_git_commit_date() const noexcept -> std::string_view { return git_commit_date; }
+    virtual constexpr auto get_build_date() const noexcept -> std::string_view { return build_date; }
+private:
+    static constexpr std::string_view git_hash = "@GIT_HASH@";
+    static constexpr std::string_view git_tag = "@GIT_TAG@";
+    static constexpr std::string_view git_branch = "@GIT_BRANCH@";
+    static constexpr std::string_view git_author = @GIT_AUTHOR@;
+    static constexpr std::string_view git_is_dirty = "@GIT_IS_DIRTY@";
+    static constexpr std::string_view git_commit_date = "@GIT_COMMIT_DATE@";
+    static constexpr std::string_view build_date = @BUILD_DATE@;
+};
+}

--- a/libs/progbase/inc/tfc/version.hpp.in
+++ b/libs/progbase/inc/tfc/version.hpp.in
@@ -5,6 +5,7 @@
 namespace tfc::base{
 class version {
 public:
+    ~version();
     virtual constexpr auto get_git_hash() const noexcept -> std::string_view { return git_hash; }
     virtual constexpr auto get_git_tag() const noexcept -> std::string_view { return git_tag; }
     virtual constexpr auto get_git_branch() const noexcept -> std::string_view { return git_branch; }

--- a/libs/progbase/src/progbase.cpp
+++ b/libs/progbase/src/progbase.cpp
@@ -39,9 +39,10 @@ public:
       auto version = base::version();
       std::stringstream out;
       desc.print(out);
-      fmt::print("TFC - https://github.com/skaginn3x/framework\nBuilt: {}, Commited: {}, Branch: {}, Hash: {}, Tag: {} - {}\n", version.get_build_date(),
-                 version.get_git_commit_date(), version.get_git_branch(), version.get_git_hash(), version.get_git_tag(),
-                 version.get_git_is_dirty());
+      fmt::print(
+          "TFC - https://github.com/skaginn3x/framework\nBuilt: {}, Commited: {}, Branch: {}, Hash: {}, Tag: {} - {}\n",
+          version.get_build_date(), version.get_git_commit_date(), version.get_git_branch(), version.get_git_hash(),
+          version.get_git_tag(), version.get_git_is_dirty());
       std::exit(0);
     }
 

--- a/libs/progbase/src/progbase.cpp
+++ b/libs/progbase/src/progbase.cpp
@@ -39,7 +39,7 @@ public:
       auto version = base::version();
       std::stringstream out;
       desc.print(out);
-      fmt::print("Built: {}, Commited: {}, Branch: {}, Hash: {}, Tag: {},  {}\n", version.get_build_date(),
+      fmt::print("TFC - https://github.com/skaginn3x/framework\nBuilt: {}, Commited: {}, Branch: {}, Hash: {}, Tag: {} - {}\n", version.get_build_date(),
                  version.get_git_commit_date(), version.get_git_branch(), version.get_git_hash(), version.get_git_tag(),
                  version.get_git_is_dirty());
       std::exit(0);

--- a/libs/progbase/src/progbase.cpp
+++ b/libs/progbase/src/progbase.cpp
@@ -1,8 +1,9 @@
 #include <ranges>
 
-#include "tfc/logger.hpp"
-#include "tfc/progbase.hpp"
-#include "tfc/utils/pragmas.hpp"
+#include <tfc/logger.hpp>
+#include <tfc/progbase.hpp>
+#include <tfc/utils/pragmas.hpp>
+#include <tfc/version.hpp>
 
 #include <fmt/printf.h>
 #include <boost/asio.hpp>
@@ -33,6 +34,16 @@ public:
     id_ = vm_["id"].as<std::string>();
     stdout_ = vm_["stdout"].as<bool>();
     noeffect_ = vm_["noeffect"].as<bool>();
+    bool wants_version = vm_["version"].as<bool>();
+    if (wants_version) {
+      auto version = base::version();
+      std::stringstream out;
+      desc.print(out);
+      fmt::print("Built: {}, Commited: {}, Branch: {}, Hash: {}, Tag: {},  {}\n", version.get_build_date(),
+                 version.get_git_commit_date(), version.get_git_branch(), version.get_git_hash(), version.get_git_tag(),
+                 version.get_git_is_dirty());
+      std::exit(0);
+    }
 
     auto log_level = vm_["log-level"].as<std::string>();
     auto enum_v = magic_enum::enum_cast<tfc::logger::lvl_e>(log_level);
@@ -57,7 +68,8 @@ public:
   [[nodiscard]] auto get_exe_name() const -> std::string_view { return exe_name_; }
   [[nodiscard]] auto get_stdout() const noexcept -> bool { return stdout_; }
   [[nodiscard]] auto get_noeffect() const noexcept -> bool { return noeffect_; }
-  [[nodiscard]] auto get_log_lvl() const noexcept -> tfc::logger::lvl_e { return log_level_; }
+  [[nodiscard]] auto get_log_lvl() const noexcept -> logger::lvl_e { return log_level_; }
+  [[nodiscard]] auto get_version() const noexcept -> base::version { return version_; }
 
 private:
   options() = default;
@@ -66,7 +78,8 @@ private:
   std::string id_{};
   std::string exe_name_{};
   bpo::variables_map vm_{};
-  tfc::logger::lvl_e log_level_{};
+  logger::lvl_e log_level_{};
+  base::version version_;
 };
 
 auto default_description() -> boost::program_options::options_description {
@@ -87,7 +100,8 @@ auto default_description() -> boost::program_options::options_description {
       "id,i", bpo::value<std::string>()->default_value("def"), "Process name used internally, max 12 characters.")(
       "noeffect", bpo::bool_switch()->default_value(false), "Process will not send any IPCs.")(
       "stdout", bpo::bool_switch()->default_value(false), "Logs displayed both in terminal and journal.")(
-      "log-level", bpo::value<std::string>()->default_value("info"), fmt::format("Set log level ({})", help_text).c_str());
+      "log-level", bpo::value<std::string>()->default_value("info"), fmt::format("Set log level ({})", help_text).c_str())(
+      "version,v", bpo::bool_switch()->default_value(false), "Print version information");
   return description;
 }
 
@@ -102,12 +116,15 @@ void init(int argc, char const* const* argv) {
 auto get_exe_name() noexcept -> std::string_view {
   return options::instance().get_exe_name();
 }
+
 auto get_proc_name() noexcept -> std::string_view {
   return options::instance().get_id();
 }
+
 auto get_log_lvl() noexcept -> tfc::logger::lvl_e {
   return options::instance().get_log_lvl();
 }
+
 auto get_map() noexcept -> boost::program_options::variables_map const& {
   return options::instance().get_map();
 }
@@ -118,6 +135,7 @@ auto get_config_directory() -> std::filesystem::path {
   }
   return std::filesystem::path{ "/etc/tfc/" };
 }
+
 auto make_config_file_name(std::string_view filename, std::string_view extension) -> std::filesystem::path {
   auto config_dir{ get_config_directory() };
   std::string filename_path{ filename };
@@ -130,6 +148,7 @@ auto make_config_file_name(std::string_view filename, std::string_view extension
 auto is_stdout_enabled() noexcept -> bool {
   return options::instance().get_stdout();
 }
+
 auto is_noeffect_enabled() noexcept -> bool {
   return options::instance().get_noeffect();
 }
@@ -147,5 +166,4 @@ auto exit_signals(asio::io_context& ctx) -> asio::awaitable<void> {
   fmt::print("\nShutting down gracefully.\nMay you have a pleasant remainder of your day.\n");
   ctx.stop();
 }
-
 }  // namespace tfc::base

--- a/libs/progbase/src/version.cpp
+++ b/libs/progbase/src/version.cpp
@@ -1,0 +1,6 @@
+//
+// this compilation unit is only here to store vtable references.
+//
+#include <tfc/version.hpp>
+
+tfc::base::version::~version() = default;


### PR DESCRIPTION
Added version.hpp to identify version of running software this should make it possible to track down the exact versions. And replicate if wanted or required.

A current shortcoming of this approach is that the values only get updated once cmake configures. I want to overcome this s.t. the vales stay correct even if "non" commited targets get deployed to an endpoint.

Example output of running `--version`
```
Built: 2024-04-14, Commited: 2024-01-14, Branch: git_version, Hash: 5adceb4e7059927ce6ebfd6354bb51537d2afb6d, Tag: 2023.11.1-96-g5adce,  dirty
```