### PR TITLE
Modified file_storage to not override configuration files

### DIFF
--- a/libs/confman/testing/tests/confman_test.cpp
+++ b/libs/confman/testing/tests/confman_test.cpp
@@ -143,7 +143,7 @@ auto main(int argc, char** argv) -> int {
         dbus, interface_name, interface_path.string(), interface_name,
         std::string{ property_name.data(), property_name.size() },
         [&called]([[maybe_unused]] std::error_code err, [[maybe_unused]] config_property prop) {
-          ut::expect(!err);
+          ut::expect(!err) << err.message();
           called++;
           glz::json_t json{};
           std::ignore = glz::read_json(json, prop.value);


### PR DESCRIPTION
Configuration files that are invalid are not overwritten any more but an error thrown.
The previous behaviour could lead to loss of data and was to forward.