### PR TITLE
fix motor config

### DIFF
--- a/libs/motor/inc/public/tfc/motor.hpp
+++ b/libs/motor/inc/public/tfc/motor.hpp
@@ -35,11 +35,12 @@ struct not_used {
   static constexpr std::string_view value{ "No motor configured" };
   auto operator==(const not_used&) const noexcept -> bool { return true; }
 };
-} // namespace details
+}  // namespace details
 
 class api {
 public:
-  using tagged_variant = std::variant<details::not_used, types::virtual_motor::config_t, types::atv320motor::config_t, types::stub::config_t>;
+  using tagged_variant =
+      std::variant<details::not_used, types::virtual_motor::config_t, types::atv320motor::config_t, types::stub::config_t>;
   using config_t = confman::observable<tagged_variant>;
 
 private:

--- a/libs/motor/inc/public/tfc/motor.hpp
+++ b/libs/motor/inc/public/tfc/motor.hpp
@@ -30,10 +30,17 @@ using mp_units::QuantityOf;
 using speedratio_t = dbus::types::speedratio_t;
 using micrometre_t = dbus::types::micrometre_t;
 
+namespace details {
+struct not_used {
+  static constexpr std::string_view value{ "No motor configured" };
+  auto operator==(const not_used&) const noexcept -> bool { return true; }
+};
+} // namespace details
+
 class api {
 public:
-  using config_t = confman::observable<
-      std::variant<std::monostate, types::virtual_motor::config_t, types::atv320motor::config_t, types::stub::config_t>>;
+  using tagged_variant = std::variant<details::not_used, types::virtual_motor::config_t, types::atv320motor::config_t, types::stub::config_t>;
+  using config_t = confman::observable<tagged_variant>;
 
 private:
   using config_internal_t = std::variant<confman::config<config_t>, std::shared_ptr<config_t>>;
@@ -78,7 +85,7 @@ public:
     std::visit(
         [this](auto& conf) {
           using conf_t = std::decay_t<decltype(conf)>;
-          if constexpr (!std::same_as<std::monostate, conf_t>) {
+          if constexpr (!std::same_as<details::not_used, conf_t>) {
             if constexpr (std::is_constructible_v<typename conf_t::impl, std::shared_ptr<sdbusplus::asio::connection>,
                                                   const conf_t&>) {
               impl_.emplace<typename conf_t::impl>(connection_, conf);
@@ -100,7 +107,7 @@ public:
       std::visit(
           [this](auto& vst_new, auto& vst_old) {
             using conf_t = std::decay_t<decltype(vst_new)>;
-            if constexpr (!std::same_as<decltype(vst_new), decltype(vst_old)> && !std::same_as<std::monostate, conf_t>) {
+            if constexpr (!std::same_as<decltype(vst_new), decltype(vst_old)> && !std::same_as<details::not_used, conf_t>) {
               logger_.info("Switching running motor config");
               if constexpr (std::is_constructible_v<typename conf_t::impl, std::shared_ptr<sdbusplus::asio::connection>,
                                                     conf_t>) {
@@ -563,3 +570,15 @@ auto api::reset(asio::completion_token_for<void(std::error_code)> auto&& token) 
 }
 
 }  // namespace tfc::motor
+
+template <>
+struct glz::meta<tfc::motor::api::tagged_variant> {
+  static constexpr std::string_view tag{ "Selected motor variant" };
+};
+
+template <>
+struct glz::meta<tfc::motor::details::not_used> {
+  using self = tfc::motor::details::not_used;
+  static constexpr std::string_view name{ "Not used" };
+  static constexpr auto value{ glz::object("value", &self::value, tfc::json::schema{ .read_only = true }) };
+};

--- a/libs/motor/inc/public/tfc/motor/atv320motor.hpp
+++ b/libs/motor/inc/public/tfc/motor/atv320motor.hpp
@@ -59,7 +59,7 @@ private:
     struct glaze {
       using T = config;
       static constexpr auto value = glz::object("slave_id", &T::slave_id);
-      static constexpr std::string_view name{ "atv320" };
+      static constexpr std::string_view name{ "Schneider ATV320" };
     };
     auto operator==(const config&) const noexcept -> bool = default;
   };

--- a/libs/motor/inc/public/tfc/motor/stub.hpp
+++ b/libs/motor/inc/public/tfc/motor/stub.hpp
@@ -36,6 +36,7 @@ struct stub {
     struct glaze {
       using T = config;
       static constexpr auto value = glz::object("name", &T::name);
+      // Todo use tfc::json::schema meta and expose variant without this type to UI
       static constexpr std::string_view name{ "stub DONT PICK" };
     };
     auto operator==(const config&) const noexcept -> bool = default;

--- a/libs/motor/inc/public/tfc/motor/virtual_motor.hpp
+++ b/libs/motor/inc/public/tfc/motor/virtual_motor.hpp
@@ -47,7 +47,7 @@ private:
                                                 "nominal",
                                                 &T::nominal,
                                                 "Speed of virtual motor in physical quantities while at 50Hz");
-      static constexpr std::string_view name{ "printing_motor" };
+      static constexpr std::string_view name{ "Virtual motor" };
     };
 
     auto operator==(const config&) const noexcept -> bool = default;

--- a/libs/motor/testing/example/motor_example.cxx
+++ b/libs/motor/testing/example/motor_example.cxx
@@ -13,8 +13,9 @@ using mp_units::percent;
 
 auto main(int argc, char** argv) -> int {
   tfc::base::init(argc, argv);
-  boost::asio::io_context ctx;
-  std::shared_ptr<sdbusplus::asio::connection> dbus{ std::make_shared<sdbusplus::asio::connection>(ctx) };
+  asio::io_context ctx;
+  std::shared_ptr dbus{ std::make_shared<sdbusplus::asio::connection>(ctx, tfc::dbus::sd_bus_open_system()) };
+  dbus->request_name(tfc::dbus::make_dbus_process_name().c_str());
   motor::api my_motor {
     dbus, "my_motor"
   };


### PR DESCRIPTION
Fix null interpretation, std::monostate inside std::shared ptr does not work well. Interpretes std::monostate as std::shared_ptr when reading json

Secondly, use tagged variant for the future. Can support multiple types of frequency drives with same config parameters, i.e. slave_id.